### PR TITLE
More prop type conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ window.customElements.define('my-element', CustomElement)
 
   - `"false"` -> `false`
 
+- Attributes with an empty string  `""` value and aren't declared with `type: Boolean` are auto-casted to `null`.
+
 - Attributes that map to props declared with `type: Number` are auto-casted into numbers if the value is a parsable number.
+
+- Attributes that map to props declared with `type: Object` and are given a string value are auto-casted into objects by parsing the string as JSON (if valid JSON). 
 
 ### Events
 

--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -43,6 +43,7 @@ function createCustomEvent (name, args) {
 
 const isBoolean = val => /function Boolean/.test(String(val));
 const isNumber = val => /function Number/.test(String(val));
+const isObject = val => /function Object/.test(String(val));
 
 function convertAttributeValue (value, name, { type } = {}) {
   if (isBoolean(type)) {
@@ -53,9 +54,19 @@ function convertAttributeValue (value, name, { type } = {}) {
       return true
     }
     return value != null
+  } else if (value === '') {
+    return null
   } else if (isNumber(type)) {
     const parsed = parseFloat(value, 10);
     return isNaN(parsed) ? value : parsed
+  } else if (isObject(type) && value !== undefined) {
+    try {
+      return JSON.parse(value)
+    } catch (error) {
+      console.error('Error parsing attribute value from JSON:', value);
+      console.error(error);
+    }
+    return null
   } else {
     return value
   }

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -40,6 +40,7 @@ function createCustomEvent (name, args) {
 
 const isBoolean = val => /function Boolean/.test(String(val));
 const isNumber = val => /function Number/.test(String(val));
+const isObject = val => /function Object/.test(String(val));
 
 function convertAttributeValue (value, name, { type } = {}) {
   if (isBoolean(type)) {
@@ -50,9 +51,19 @@ function convertAttributeValue (value, name, { type } = {}) {
       return true
     }
     return value != null
+  } else if (value === '') {
+    return null
   } else if (isNumber(type)) {
     const parsed = parseFloat(value, 10);
     return isNaN(parsed) ? value : parsed
+  } else if (isObject(type) && value !== undefined) {
+    try {
+      return JSON.parse(value)
+    } catch (error) {
+      console.error('Error parsing attribute value from JSON:', value);
+      console.error(error);
+    }
+    return null
   } else {
     return value
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,9 +40,9 @@ export function createCustomEvent (name, args) {
 
 const isBoolean = val => /function Boolean/.test(String(val))
 const isNumber = val => /function Number/.test(String(val))
-const isObject = val => /function Object/.test(String(val));
+const isObject = val => /function Object/.test(String(val))
 
-function convertAttributeValue (value, name, { type } = {}) {
+export function convertAttributeValue (value, name, { type } = {}) {
   if (isBoolean(type)) {
     if (value === 'true' || value === 'false') {
       return value === 'true'
@@ -54,13 +54,13 @@ function convertAttributeValue (value, name, { type } = {}) {
   } else if (value === '') {
     return null
   } else if (isNumber(type)) {
-    const parsed = parseFloat(value, 10);
+    const parsed = parseFloat(value, 10)
     return isNaN(parsed) ? value : parsed
   } else if (isObject(type) && value !== undefined) {
     try {
       return JSON.parse(value)
     } catch (error) {
-      console.error("Error parsing attribute value from JSON:", value)
+      console.error('Error parsing attribute value from JSON:', value)
       console.error(error)
     }
     return null

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,8 +40,9 @@ export function createCustomEvent (name, args) {
 
 const isBoolean = val => /function Boolean/.test(String(val))
 const isNumber = val => /function Number/.test(String(val))
+const isObject = val => /function Object/.test(String(val));
 
-export function convertAttributeValue (value, name, { type } = {}) {
+function convertAttributeValue (value, name, { type } = {}) {
   if (isBoolean(type)) {
     if (value === 'true' || value === 'false') {
       return value === 'true'
@@ -50,9 +51,19 @@ export function convertAttributeValue (value, name, { type } = {}) {
       return true
     }
     return value != null
+  } else if (value === '') {
+    return null
   } else if (isNumber(type)) {
-    const parsed = parseFloat(value, 10)
+    const parsed = parseFloat(value, 10);
     return isNaN(parsed) ? value : parsed
+  } else if (isObject(type) && value !== undefined) {
+    try {
+      return JSON.parse(value)
+    } catch (error) {
+      console.error("Error parsing attribute value from JSON:", value)
+      console.error(error)
+    }
+    return null
   } else {
     return value
   }

--- a/test/fixtures/attributes.html
+++ b/test/fixtures/attributes.html
@@ -13,6 +13,15 @@ customElements.define('my-element', wrap(Vue, {
     },
     someNumber: {
       type: Number
+    },
+    spit: {
+      type: Boolean
+    },
+    noodle: {
+      type: Object
+    },
+    moreNumber: {
+      type: Number
     }
   }
 }))
@@ -20,4 +29,4 @@ customElements.define('my-element', wrap(Vue, {
 window.el = document.querySelector('my-element')
 </script>
 
-<my-element foo="foo" bar="true" some-number="123"></my-element>
+<my-element foo="foo" bar="true" some-number="123" spit="" noodle='{"fred": "flinstone"}' more-number=""></my-element>

--- a/test/test.js
+++ b/test/test.js
@@ -37,6 +37,18 @@ test('attributes', async () => {
   const someNumber = await page.evaluate(() => el.someNumber)
   expect(someNumber).toBe(123)
 
+  // spit=""
+  const spit = await page.evaluate(() => el.spit)
+  expect(spit).toBe(true)
+
+  // noodle='{"fred": "flinstone"}'
+  const noodle = await page.evaluate(() => el.noodle)
+  expect(noodle).toEqual({ fred: 'flinstone' })
+
+  // more-number=""
+  const moreNumber = await page.evaluate(() => el.moreNumber)
+  expect(moreNumber).toBe(null)
+
   // set via attribute
   await page.evaluate(() => {
     el.setAttribute('foo', 'foo')


### PR DESCRIPTION
Since custom elements aren't always going to have a parent Vue instance, the properties are going to come in as a string and we need a sensible way of converting those strings to useful values otherwise it blows up the Vue property type checker.

This PR certainly fulfills my use case, but I'm not sure it's gonna fit everyone's. It'd be nice to maybe have more hooks into the element creation process to customize it.