### PR TITLE
Add option to not use shadow DOM

### DIFF
--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -98,7 +98,15 @@ function getAttributes (node) {
   return res
 }
 
-function wrap (Vue, Component) {
+/** @typedef {object} Options
+ * @prop {boolean} [useShadowDOM = true]
+ */
+
+/**
+ * @param {Options} options
+ */
+function wrap (Vue, Component, options = {}) {
+  const { useShadowDOM = true } = options;
   const isAsync = typeof Component === 'function' && !Component.cid;
   let isInitialized = false;
   let hyphenatedPropsList;
@@ -170,7 +178,7 @@ function wrap (Vue, Component) {
   class CustomElement extends HTMLElement {
     constructor () {
       super();
-      this.attachShadow({ mode: 'open' });
+      if (useShadowDOM) this.attachShadow({ mode: 'open' });
 
       const wrapper = this._wrapper = new Vue({
         name: 'shadow-root',
@@ -249,7 +257,9 @@ function wrap (Vue, Component) {
           this.childNodes
         ));
         wrapper.$mount();
-        this.shadowRoot.appendChild(wrapper.$el);
+        // render element to DOM
+        if (useShadowDOM) this.shadowRoot.appendChild(wrapper.$el);
+        else this.appendChild(wrapper.$el);
       } else {
         callHooks(this.vueComponent, 'activated');
       }

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -95,7 +95,15 @@ function getAttributes (node) {
   return res
 }
 
-function wrap (Vue, Component) {
+/** @typedef {object} Options
+ * @prop {boolean} [useShadowDOM = true]
+ */
+
+/**
+ * @param {Options} options
+ */
+function wrap (Vue, Component, options = {}) {
+  const { useShadowDOM = true } = options;
   const isAsync = typeof Component === 'function' && !Component.cid;
   let isInitialized = false;
   let hyphenatedPropsList;
@@ -167,7 +175,7 @@ function wrap (Vue, Component) {
   class CustomElement extends HTMLElement {
     constructor () {
       super();
-      this.attachShadow({ mode: 'open' });
+      if (useShadowDOM) this.attachShadow({ mode: 'open' });
 
       const wrapper = this._wrapper = new Vue({
         name: 'shadow-root',
@@ -246,7 +254,9 @@ function wrap (Vue, Component) {
           this.childNodes
         ));
         wrapper.$mount();
-        this.shadowRoot.appendChild(wrapper.$el);
+        // render element to DOM
+        if (useShadowDOM) this.shadowRoot.appendChild(wrapper.$el);
+        else this.appendChild(wrapper.$el);
       } else {
         callHooks(this.vueComponent, 'activated');
       }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pre-commit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": [
+    "src/*.js": [
       "eslint --fix",
       "git add"
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,15 @@ import {
   convertAttributeValue
 } from './utils.js'
 
-export default function wrap (Vue, Component) {
+/** @typedef {object} Options
+ * @prop {boolean} [useShadowDOM = true]
+ */
+
+/**
+ * @param {Options} options
+ */
+export default function wrap (Vue, Component, options = {}) {
+  const { useShadowDOM = true } = options
   const isAsync = typeof Component === 'function' && !Component.cid
   let isInitialized = false
   let hyphenatedPropsList
@@ -81,7 +89,7 @@ export default function wrap (Vue, Component) {
   class CustomElement extends HTMLElement {
     constructor () {
       super()
-      this.attachShadow({ mode: 'open' })
+      if (useShadowDOM) this.attachShadow({ mode: 'open' })
 
       const wrapper = this._wrapper = new Vue({
         name: 'shadow-root',
@@ -160,7 +168,9 @@ export default function wrap (Vue, Component) {
           this.childNodes
         ))
         wrapper.$mount()
-        this.shadowRoot.appendChild(wrapper.$el)
+        // render element to DOM
+        if (useShadowDOM) this.shadowRoot.appendChild(wrapper.$el)
+        else this.appendChild(wrapper.$el)
       } else {
         callHooks(this.vueComponent, 'activated')
       }


### PR DESCRIPTION
I am using [vue-styled-components](https://github.com/styled-components/vue-styled-components) in a project which I want to export as a web-component because it will be put into an existing Angular 1 app.
The problem is: the styles are dynamically put into the global document, and there is no easy way to put it inside the shadow DOM (shadowRoot) in the current code.
This PR adds a third parameter which can be used to set options, with a single one for now, which can be used to disable the shadow dom usage.
It's still needed to add the documentation to the README, but please tell me if this is ok to be merged so I can write it just once