### PR TITLE
feat: customise html element inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ const CustomElement = wrap(Vue, () => import(`MyComponent.vue`))
 window.customElements.define('my-element', CustomElement)
 ```
 
+Further more it is possible to change the class your custom element should inherit from by providing a third parameter. This way you can customize built-in elements as well:
+
+``` js
+import Vue from 'vue'
+import wrap from '@vue/web-component-wrapper'
+
+const ListComponent = {
+  // any component options
+}
+
+const CustomListElement = wrap(Vue, Component, HTMLUListElement)
+
+window.customElements.define('my-list', CustomElement, { extends: 'ul' })
+```
+
 ## Interface Proxying Details
 
 ### Props

--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -98,7 +98,7 @@ function getAttributes (node) {
   return res
 }
 
-function wrap (Vue, Component) {
+function wrap (Vue, Component, Element = HTMLElement) {
   const isAsync = typeof Component === 'function' && !Component.cid;
   let isInitialized = false;
   let hyphenatedPropsList;
@@ -167,7 +167,7 @@ function wrap (Vue, Component) {
     );
   }
 
-  class CustomElement extends HTMLElement {
+  class CustomElement extends Element {
     constructor () {
       super();
       this.attachShadow({ mode: 'open' });

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -95,7 +95,7 @@ function getAttributes (node) {
   return res
 }
 
-function wrap (Vue, Component) {
+function wrap (Vue, Component, Element = HTMLElement) {
   const isAsync = typeof Component === 'function' && !Component.cid;
   let isInitialized = false;
   let hyphenatedPropsList;
@@ -164,7 +164,7 @@ function wrap (Vue, Component) {
     );
   }
 
-  class CustomElement extends HTMLElement {
+  class CustomElement extends Element {
     constructor () {
       super();
       this.attachShadow({ mode: 'open' });

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import {
   convertAttributeValue
 } from './utils.js'
 
-export default function wrap (Vue, Component) {
+export default function wrap (Vue, Component, Element = HTMLElement) {
   const isAsync = typeof Component === 'function' && !Component.cid
   let isInitialized = false
   let hyphenatedPropsList
@@ -78,7 +78,7 @@ export default function wrap (Vue, Component) {
     )
   }
 
-  class CustomElement extends HTMLElement {
+  class CustomElement extends Element {
     constructor () {
       super()
       this.attachShadow({ mode: 'open' })


### PR DESCRIPTION
Via web components it is possible to create two different kind of custom elements:

> * Autonomous custom elements are standalone — they don't inherit from standard HTML elements. You use these on a page by literally writing them out as an HTML element. For example `<popup-info>`, or `document.createElement("popup-info")`.
> * Customized built-in elements inherit from basic HTML elements. To create one of these, you have to specify which element they extend (as implied in the examples above), and they are used by writing out the basic element but specifying the name of the custom element in the `is` attribute (or property). For example `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.

https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements

This PR adds the possibility to change the base element class used for wrapping the Vue component:

``` js
import Vue from 'vue'
import wrap from '@vue/web-component-wrapper'

const ListComponent = {
  // any component options
}

const CustomListElement = wrap(Vue, Component, HTMLUListElement)

window.customElements.define('my-list', CustomElement, { extends: 'ul' })
```