### PR TITLE
fix: CustomElement constructor for compatibility with other polyfills

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,14 +79,14 @@ export default function wrap (Vue, Component) {
   }
 
   class CustomElement extends HTMLElement {
-    constructor () {
-      super()
-      this.attachShadow({ mode: 'open' })
+    constructor (...args) {
+      const self = super(...args)
+      self.attachShadow({ mode: 'open' })
 
-      const wrapper = this._wrapper = new Vue({
+      const wrapper = self._wrapper = new Vue({
         name: 'shadow-root',
-        customElement: this,
-        shadowRoot: this.shadowRoot,
+        customElement: self,
+        shadowRoot: self.shadowRoot,
         data () {
           return {
             props: {},
@@ -106,8 +106,8 @@ export default function wrap (Vue, Component) {
         let hasChildrenChange = false
         for (let i = 0; i < mutations.length; i++) {
           const m = mutations[i]
-          if (isInitialized && m.type === 'attributes' && m.target === this) {
-            syncAttribute(this, m.attributeName)
+          if (isInitialized && m.type === 'attributes' && m.target === self) {
+            syncAttribute(self, m.attributeName)
           } else {
             hasChildrenChange = true
           }
@@ -115,11 +115,11 @@ export default function wrap (Vue, Component) {
         if (hasChildrenChange) {
           wrapper.slotChildren = Object.freeze(toVNodes(
             wrapper.$createElement,
-            this.childNodes
+            self.childNodes
           ))
         }
       })
-      observer.observe(this, {
+      observer.observe(self, {
         childList: true,
         subtree: true,
         characterData: true,

--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,8 @@ export default function wrap (Vue, Component) {
   }
 
   class CustomElement extends HTMLElement {
-    constructor (...args) {
-      const self = super(...args)
+    constructor () {
+      const self = super()
       self.attachShadow({ mode: 'open' })
 
       const wrapper = self._wrapper = new Vue({


### PR DESCRIPTION
This PR makes vue-web-component-wrapper compatible with the [document-register-element](https://github.com/WebReflection/document-register-element) polyfill.

See https://github.com/WebReflection/document-register-element/issues/148