### PR TITLE
Fix: sync element's properties when async component is resolved

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,14 +142,6 @@ export default function wrap (Vue, Component) {
           })
         }
 
-        const syncProperties = () => {
-          camelizedPropsList.forEach(prop => {
-            if (typeof this[prop] !== 'undefined') {
-              wrapper.props[prop] = this[prop]
-            }
-          })
-        }
-
         if (isInitialized) {
           syncInitialAttributes()
         } else {
@@ -160,7 +152,12 @@ export default function wrap (Vue, Component) {
             }
             initialize(resolved)
             syncInitialAttributes()
-            syncProperties()
+            // sync existing element properties with props
+            camelizedPropsList.forEach(prop => {
+              if (typeof this[prop] !== 'undefined') {
+                wrapper.props[prop] = this[prop]
+              }
+            })
           })
         }
         // initialize children

--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,14 @@ export default function wrap (Vue, Component) {
           })
         }
 
+        const syncProperties = () => {
+          camelizedPropsList.forEach(prop => {
+            if (typeof this[prop] !== 'undefined') {
+              wrapper.props[prop] = this[prop]
+            }
+          })
+        }
+
         if (isInitialized) {
           syncInitialAttributes()
         } else {
@@ -152,6 +160,7 @@ export default function wrap (Vue, Component) {
             }
             initialize(resolved)
             syncInitialAttributes()
+            syncProperties()
           })
         }
         // initialize children

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "jest": true
+    },
+    "globals": {
+        "el": true,
+        "els": true
+    }
+}

--- a/test/fixtures/async.html
+++ b/test/fixtures/async.html
@@ -5,7 +5,7 @@ import wrap from '../../src/index.js'
 const Component = () => new Promise(resolve => {
   setTimeout(() => {
     resolve({
-      template: `<div>{{ foo }} {{ someProp }}</div>`,
+      template: `<div>{{ foo }} {{ someProp }} {{ extraProp.value }}</div>`,
       props: {
         foo: {
           type: Number,
@@ -14,6 +14,10 @@ const Component = () => new Promise(resolve => {
         'some-prop': {
           type: String,
           default: 'bar'
+        },
+        extraProp: {
+          type: Object,
+          default: () => ({value: 'banana'})
         }
       }
     })
@@ -26,6 +30,7 @@ const Component = () => new Promise(resolve => {
 customElements.define('my-element', wrap(Vue, Component))
 
 window.els = document.querySelectorAll('my-element')
+window.els[1].extraProp = {value: 'apple'}
 </script>
 
 <my-element></my-element>

--- a/test/test.js
+++ b/test/test.js
@@ -16,9 +16,9 @@ test('properties', async () => {
     el.foo = 234
     el.someProp = 'lol'
   })
-  const newFoo = await page.evaluate(()  => el.vueComponent.foo)
+  const newFoo = await page.evaluate(() => el.vueComponent.foo)
   expect(newFoo).toBe(234)
-  const newBar = await page.evaluate(()  => el.vueComponent.someProp)
+  const newBar = await page.evaluate(() => el.vueComponent.someProp)
   expect(newBar).toBe('lol')
 })
 
@@ -113,6 +113,9 @@ test('async', async () => {
   // both instances should be initialized
   expect(await page.evaluate(() => els[0].shadowRoot.textContent)).toMatch(`123 bar`)
   expect(await page.evaluate(() => els[1].shadowRoot.textContent)).toMatch(`234 baz`)
+
+  // props assigned as node properties should be synced
+  expect(await page.evaluate(() => els[1].shadowRoot.textContent)).toMatch(`apple`)
 
   // attribute sync should work
   await page.evaluate(() => {


### PR DESCRIPTION
This PR fixes #63 

The proposal is to sync the already defined element's properties with the component's props then async component is loaded.

_Also includes .eslintrc for tests folder_