### PR TITLE
Added message about vue cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @vue/web-component-wrapper [![CircleCI](https://circleci.com/gh/vuejs/vue-web-component-wrapper.svg?style=shield)](https://circleci.com/gh/vuejs/vue-web-component-wrapper)
 
-> Wrap and register a Vue component as a custom element.
+> Wrap and register a Vue component as a custom element. This project is intended for internal use by the [Vue CLI](https://github.com/vuejs/vue-cli)
 
 ## Compatibility
 


### PR DESCRIPTION
There are a number of closed issues saying that it's weird to attempt to use this repo for custom things because it is meant to be used by vue-cli. In that case it should probably state that in the project documentation.