### PR TITLE
fix #34, #63, #72: ignored props before component connects

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,15 @@
     "env": {
       "browser": true
     },
-    "extends": "plugin:vue-libs/recommended"
+    "extends": "plugin:vue-libs/recommended",
+    "overrides": [
+      {
+        "files": ["test/*"],
+        "env": {
+          "jest": true
+        }
+      }
+    ]
   },
   "gitHooks": {
     "pre-commit": "lint-staged"

--- a/src/index.js
+++ b/src/index.js
@@ -136,10 +136,14 @@ export default function wrap (Vue, Component) {
       if (!wrapper._isMounted) {
         // initialize attributes
         const syncInitialAttributes = () => {
-          wrapper.props = getInitialProps(camelizedPropsList)
-          hyphenatedPropsList.forEach(key => {
-            syncAttribute(this, key)
-          })
+          const initialProps = getInitialProps(camelizedPropsList, this)
+          const isUndefined = key => initialProps[camelize(key)] === undefined
+          wrapper.props = initialProps
+          hyphenatedPropsList
+            .filter(key => this.hasAttribute(key) || isUndefined(key))
+            .forEach(key => {
+              syncAttribute(this, key)
+            })
         }
 
         if (isInitialized) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,10 +8,10 @@ export const hyphenate = str => {
   return str.replace(hyphenateRE, '-$1').toLowerCase()
 }
 
-export function getInitialProps (propsList) {
+export function getInitialProps (propsList, el) {
   const res = {}
   propsList.forEach(key => {
-    res[key] = undefined
+    res[key] = el[key]
   })
   return res
 }

--- a/test/fixtures/mounting-manually.html
+++ b/test/fixtures/mounting-manually.html
@@ -1,0 +1,23 @@
+<script src="../../node_modules/vue/dist/vue.js"></script>
+<script type="module">
+import wrap from '../../src/index.js'
+
+window.MyElement = wrap(Vue, {
+  template: `<div>{{ foo }} {{ someProp }}</div>`,
+  props: {
+    foo: {
+      type: Number,
+      default: 123
+    },
+    'some-prop': {
+      type: String,
+      default: 'bar'
+    }
+  },
+  mounted () {
+    console.log(`mounted with foo: ${this.foo}`)
+    console.log(`mounted with someProp: ${this.someProp}`)
+  }
+})
+customElements.define('my-element', window.MyElement)
+</script>

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,7 @@
 const launchPage = require('./setup')
 
+/* global el, els, MyElement */
+
 test('properties', async () => {
   const { page } = await launchPage(`properties`)
 
@@ -16,9 +18,9 @@ test('properties', async () => {
     el.foo = 234
     el.someProp = 'lol'
   })
-  const newFoo = await page.evaluate(()  => el.vueComponent.foo)
+  const newFoo = await page.evaluate(() => el.vueComponent.foo)
   expect(newFoo).toBe(234)
-  const newBar = await page.evaluate(()  => el.vueComponent.someProp)
+  const newBar = await page.evaluate(() => el.vueComponent.someProp)
   expect(newBar).toBe('lol')
 })
 
@@ -129,4 +131,27 @@ test('async', async () => {
   expect(await page.evaluate(() => {
     return document.querySelectorAll('my-element')[2].shadowRoot.textContent
   })).toMatch(`456 bar`)
+})
+
+test('mounting manually', async () => {
+  const { page, logs } = await launchPage(`mounting-manually`)
+
+  // mounting programmatically
+  await page.evaluate(() => {
+    window.el = new MyElement()
+    window.el.foo = 234
+    window.el.setAttribute('some-prop', 'lol')
+    window.el.someProp = 'ignored as attribute takes precedence'
+    document.body.appendChild(window.el)
+  })
+
+  // props
+  const foo = await page.evaluate(() => el.vueComponent.foo)
+  expect(foo).toBe(234)
+  const bar = await page.evaluate(() => el.vueComponent.someProp)
+  expect(bar).toBe('lol')
+
+  // lifecycle
+  expect(logs).toContain('mounted with foo: 234')
+  expect(logs).toContain('mounted with someProp: lol')
 })


### PR DESCRIPTION
Added awareness to CustomElement props in the initialization code. In order to stay backward compatible opted for attributes taking precedence. In scenarios, where users already set conflicting attributes and props, the component's behavior will remain unchanged.

Intends to:
- fix #34
- fix #63 
- fix #72

_Note that I also added Jest and in-comment globals to ESLint setup to make it pass on tests._