### PR TITLE
Plugin render in the new Vue initial instance 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ const CustomElement = wrap(Vue, () => import(`MyComponent.vue`))
 
 window.customElements.define('my-element', CustomElement)
 ```
+### Usage with addtional attributes
+```js
+const vueAttributeBeforeRender = {
+        i18n:{ locale: 'de' },
+        foo:{ bar: 'test' },
+}; 
+
+const CustomElement = wrap(Vue, Component, vueAttributeBeforeRender)
+```
+This will add the attribute to the 
+```js  
+new Vue({ // attributes }) 
+```
 
 ## Interface Proxying Details
 


### PR DESCRIPTION
Add option to pass arguments to main wrap function, the argument will add attribute to the new Vue initial instantiation.
For use case of a plugin that must be instantiated in the initial new Vue, and therefore the global attributes / instance properties will be available on the vm.$root