### PR TITLE
fix:  options from the extended component are not inherited

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ import {
 
 export default function wrap (Vue, Component) {
   const isAsync = typeof Component === 'function' && !Component.cid
+
+  if (!isAsync && Component.extends && Vue.util.mergeOptions) {
+    Component = Vue.util.mergeOptions(Component, Component.extends)
+  }
   let isInitialized = false
   let hyphenatedPropsList
   let camelizedPropsList

--- a/test/fixtures/extended-component-properties.html
+++ b/test/fixtures/extended-component-properties.html
@@ -1,0 +1,26 @@
+<script src="../../node_modules/vue/dist/vue.js"></script>
+<script type="module">
+import wrap from '../../src/index.js'
+
+const component = {
+  template: `<div>{{ foo }} {{ someProp }}</div>`,
+  props: {
+    foo: {
+      type: Number,
+      default: 123
+    },
+    'some-prop': {
+      type: String,
+      default: 'bar'
+    }
+  }
+}
+
+customElements.define('my-element', wrap(Vue, {
+  extends: component,
+}))
+
+window.el = document.querySelector('my-element')
+</script>
+
+<my-element></my-element>

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,29 @@ test('properties', async () => {
   expect(newBar).toBe('lol')
 })
 
+test('extended-component-properties', async () => {
+  const { page } = await launchPage(`extended-component-properties`)
+
+  // props proxying: get
+  const foo = await page.evaluate(() => el.foo)
+  expect(foo).toBe(123)
+
+  // get camelCase
+  const someProp = await page.evaluate(() => el.someProp)
+  expect(someProp).toBe('bar')
+
+  // props proxying: set
+  await page.evaluate(() => {
+    el.foo = 234
+    el.someProp = 'lol'
+  })
+  const newFoo = await page.evaluate(() => el.vueComponent.foo)
+
+  expect(newFoo).toBe(234)
+  const newBar = await page.evaluate(() => el.vueComponent.someProp)
+  expect(newBar).toBe('lol')
+})
+
 test('attributes', async () => {
   const { page } = await launchPage(`attributes`)
 


### PR DESCRIPTION
Hello,

This PR fixes the issue where options from the extended component are not inherited.

Fixes #119