### PR TITLE
Proxy VueComponent methods on CustomElement

### DIFF
--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -1,272 +1,283 @@
 var wrapVueWebComponent = (function () {
-'use strict';
+  'use strict';
 
-const camelizeRE = /-(\w)/g;
-const camelize = str => {
-  return str.replace(camelizeRE, (_, c) => c ? c.toUpperCase() : '')
-};
+  const camelizeRE = /-(\w)/g;
+  const camelize = str => {
+    return str.replace(camelizeRE, (_, c) => c ? c.toUpperCase() : '')
+  };
 
-const hyphenateRE = /\B([A-Z])/g;
-const hyphenate = str => {
-  return str.replace(hyphenateRE, '-$1').toLowerCase()
-};
+  const hyphenateRE = /\B([A-Z])/g;
+  const hyphenate = str => {
+    return str.replace(hyphenateRE, '-$1').toLowerCase()
+  };
 
-function getInitialProps (propsList) {
-  const res = {};
-  propsList.forEach(key => {
-    res[key] = undefined;
-  });
-  return res
-}
-
-function injectHook (options, key, hook) {
-  options[key] = [].concat(options[key] || []);
-  options[key].unshift(hook);
-}
-
-function callHooks (vm, hook) {
-  if (vm) {
-    const hooks = vm.$options[hook] || [];
-    hooks.forEach(hook => {
-      hook.call(vm);
+  function getInitialProps (propsList) {
+    const res = {};
+    propsList.forEach(key => {
+      res[key] = undefined;
     });
+    return res
   }
-}
 
-function createCustomEvent (name, args) {
-  return new CustomEvent(name, {
-    bubbles: false,
-    cancelable: false,
-    detail: args
-  })
-}
+  function injectHook (options, key, hook) {
+    options[key] = [].concat(options[key] || []);
+    options[key].unshift(hook);
+  }
 
-const isBoolean = val => /function Boolean/.test(String(val));
-const isNumber = val => /function Number/.test(String(val));
-
-function convertAttributeValue (value, name, { type } = {}) {
-  if (isBoolean(type)) {
-    if (value === 'true' || value === 'false') {
-      return value === 'true'
+  function callHooks (vm, hook) {
+    if (vm) {
+      const hooks = vm.$options[hook] || [];
+      hooks.forEach(hook => {
+        hook.call(vm);
+      });
     }
-    if (value === '' || value === name || value != null) {
-      return true
-    }
-    return value
-  } else if (isNumber(type)) {
-    const parsed = parseFloat(value, 10);
-    return isNaN(parsed) ? value : parsed
-  } else {
-    return value
   }
-}
 
-function toVNodes (h, children) {
-  const res = [];
-  for (let i = 0, l = children.length; i < l; i++) {
-    res.push(toVNode(h, children[i]));
+  function createCustomEvent (name, args) {
+    return new CustomEvent(name, {
+      bubbles: false,
+      cancelable: false,
+      detail: args
+    })
   }
-  return res
-}
 
-function toVNode (h, node) {
-  if (node.nodeType === 3) {
-    return node.data.trim() ? node.data : null
-  } else if (node.nodeType === 1) {
-    const data = {
-      attrs: getAttributes(node),
-      domProps: {
-        innerHTML: node.innerHTML
+  const isBoolean = val => /function Boolean/.test(String(val));
+  const isNumber = val => /function Number/.test(String(val));
+
+  function convertAttributeValue (value, name, { type } = {}) {
+    if (isBoolean(type)) {
+      if (value === 'true' || value === 'false') {
+        return value === 'true'
       }
-    };
-    if (data.attrs.slot) {
-      data.slot = data.attrs.slot;
-      delete data.attrs.slot;
+      if (value === '' || value === name || value != null) {
+        return true
+      }
+      return value
+    } else if (isNumber(type)) {
+      const parsed = parseFloat(value, 10);
+      return isNaN(parsed) ? value : parsed
+    } else {
+      return value
     }
-    return h(node.tagName, data)
-  } else {
-    return null
   }
-}
 
-function getAttributes (node) {
-  const res = {};
-  for (let i = 0, l = node.attributes.length; i < l; i++) {
-    const attr = node.attributes[i];
-    res[attr.nodeName] = attr.nodeValue;
+  function toVNodes (h, children) {
+    const res = [];
+    for (let i = 0, l = children.length; i < l; i++) {
+      res.push(toVNode(h, children[i]));
+    }
+    return res
   }
-  return res
-}
 
-function wrap (Vue, Component) {
-  const isAsync = typeof Component === 'function' && !Component.cid;
-  let isInitialized = false;
-  let hyphenatedPropsList;
-  let camelizedPropsList;
-  let camelizedPropsMap;
-
-  function initialize (Component) {
-    if (isInitialized) return
-
-    const options = typeof Component === 'function'
-      ? Component.options
-      : Component;
-
-    // extract props info
-    const propsList = Array.isArray(options.props)
-      ? options.props
-      : Object.keys(options.props || {});
-    hyphenatedPropsList = propsList.map(hyphenate);
-    camelizedPropsList = propsList.map(camelize);
-    const originalPropsAsObject = Array.isArray(options.props) ? {} : options.props || {};
-    camelizedPropsMap = camelizedPropsList.reduce((map, key, i) => {
-      map[key] = originalPropsAsObject[propsList[i]];
-      return map
-    }, {});
-
-    // proxy $emit to native DOM events
-    injectHook(options, 'beforeCreate', function () {
-      const emit = this.$emit;
-      this.$emit = (name, ...args) => {
-        this.$root.$options.customElement.dispatchEvent(createCustomEvent(name, args));
-        return emit.call(this, name, ...args)
+  function toVNode (h, node) {
+    if (node.nodeType === 3) {
+      return node.data.trim() ? node.data : null
+    } else if (node.nodeType === 1) {
+      const data = {
+        attrs: getAttributes(node),
+        domProps: {
+          innerHTML: node.innerHTML
+        }
       };
-    });
+      if (data.attrs.slot) {
+        data.slot = data.attrs.slot;
+        delete data.attrs.slot;
+      }
+      return h(node.tagName, data)
+    } else {
+      return null
+    }
+  }
 
-    injectHook(options, 'created', function () {
-      // sync default props values to wrapper on created
+  function getAttributes (node) {
+    const res = {};
+    for (let i = 0, l = node.attributes.length; i < l; i++) {
+      const attr = node.attributes[i];
+      res[attr.nodeName] = attr.nodeValue;
+    }
+    return res
+  }
+
+  function wrap (Vue, Component) {
+    const isAsync = typeof Component === 'function' && !Component.cid;
+    let isInitialized = false;
+    let hyphenatedPropsList;
+    let camelizedPropsList;
+    let camelizedPropsMap;
+
+    function initialize (Component) {
+      if (isInitialized) return
+
+      const options = typeof Component === 'function'
+        ? Component.options
+        : Component;
+
+      // extract props info
+      const propsList = Array.isArray(options.props)
+        ? options.props
+        : Object.keys(options.props || {});
+      hyphenatedPropsList = propsList.map(hyphenate);
+      camelizedPropsList = propsList.map(camelize);
+      const originalPropsAsObject = Array.isArray(options.props) ? {} : options.props || {};
+      camelizedPropsMap = camelizedPropsList.reduce((map, key, i) => {
+        map[key] = originalPropsAsObject[propsList[i]];
+        return map
+      }, {});
+
+      // proxy $emit to native DOM events
+      injectHook(options, 'beforeCreate', function () {
+        const emit = this.$emit;
+        this.$emit = (name, ...args) => {
+          this.$root.$options.customElement.dispatchEvent(createCustomEvent(name, args));
+          return emit.call(this, name, ...args)
+        };
+      });
+
+      injectHook(options, 'created', function () {
+        // sync default props values to wrapper on created
+        camelizedPropsList.forEach(key => {
+          this.$root.props[key] = this[key];
+        });
+      });
+
+      // proxy methods as Element methods
+      Object.keys(options.methods || {}).forEach(key => {
+        Object.defineProperty(CustomElement.prototype, key, {
+          value (...args) {
+            // _wrapper.$refs.inner
+            return options.methods[key].call(this.vueComponent, ...args)
+            //return this.vueComponent[key](...args)
+          }
+        });
+      });
+
+      // proxy props as Element properties
       camelizedPropsList.forEach(key => {
-        this.$root.props[key] = this[key];
+        Object.defineProperty(CustomElement.prototype, key, {
+          get () {
+            return this._wrapper.props[key]
+          },
+          set (newVal) {
+            this._wrapper.props[key] = newVal;
+          },
+          enumerable: false,
+          configurable: true
+        });
       });
-    });
 
-    // proxy props as Element properties
-    camelizedPropsList.forEach(key => {
-      Object.defineProperty(CustomElement.prototype, key, {
-        get () {
-          return this._wrapper.props[key]
-        },
-        set (newVal) {
-          this._wrapper.props[key] = newVal;
-        },
-        enumerable: false,
-        configurable: true
-      });
-    });
+      isInitialized = true;
+    }
 
-    isInitialized = true;
-  }
+    function syncAttribute (el, key) {
+      const camelized = camelize(key);
+      const value = el.hasAttribute(key) ? el.getAttribute(key) : undefined;
+      el._wrapper.props[camelized] = convertAttributeValue(
+        value,
+        key,
+        camelizedPropsMap[camelized]
+      );
+    }
 
-  function syncAttribute (el, key) {
-    const camelized = camelize(key);
-    const value = el.hasAttribute(key) ? el.getAttribute(key) : undefined;
-    el._wrapper.props[camelized] = convertAttributeValue(
-      value,
-      key,
-      camelizedPropsMap[camelized]
-    );
-  }
+    class CustomElement extends HTMLElement {
+      constructor () {
+        const self = super();
+        self.attachShadow({ mode: 'open' });
 
-  class CustomElement extends HTMLElement {
-    constructor () {
-      const self = super();
-      self.attachShadow({ mode: 'open' });
-
-      const wrapper = self._wrapper = new Vue({
-        name: 'shadow-root',
-        customElement: self,
-        shadowRoot: self.shadowRoot,
-        data () {
-          return {
-            props: {},
-            slotChildren: []
+        const wrapper = self._wrapper = new Vue({
+          name: 'shadow-root',
+          customElement: self,
+          shadowRoot: self.shadowRoot,
+          data () {
+            return {
+              props: {},
+              slotChildren: []
+            }
+          },
+          render (h) {
+            return h(Component, {
+              ref: 'inner',
+              props: this.props
+            }, this.slotChildren)
           }
-        },
-        render (h) {
-          return h(Component, {
-            ref: 'inner',
-            props: this.props
-          }, this.slotChildren)
-        }
-      });
+        });
 
-      // Use MutationObserver to react to future attribute & slot content change
-      const observer = new MutationObserver(mutations => {
-        let hasChildrenChange = false;
-        for (let i = 0; i < mutations.length; i++) {
-          const m = mutations[i];
-          if (isInitialized && m.type === 'attributes' && m.target === self) {
-            syncAttribute(self, m.attributeName);
+        // Use MutationObserver to react to future attribute & slot content change
+        const observer = new MutationObserver(mutations => {
+          let hasChildrenChange = false;
+          for (let i = 0; i < mutations.length; i++) {
+            const m = mutations[i];
+            if (isInitialized && m.type === 'attributes' && m.target === self) {
+              syncAttribute(self, m.attributeName);
+            } else {
+              hasChildrenChange = true;
+            }
+          }
+          if (hasChildrenChange) {
+            wrapper.slotChildren = Object.freeze(toVNodes(
+              wrapper.$createElement,
+              self.childNodes
+            ));
+          }
+        });
+        observer.observe(self, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+          attributes: true
+        });
+      }
+
+      get vueComponent () {
+        return this._wrapper.$refs.inner
+      }
+
+      connectedCallback () {
+        const wrapper = this._wrapper;
+        if (!wrapper._isMounted) {
+          // initialize attributes
+          const syncInitialAttributes = () => {
+            wrapper.props = getInitialProps(camelizedPropsList);
+            hyphenatedPropsList.forEach(key => {
+              syncAttribute(this, key);
+            });
+          };
+
+          if (isInitialized) {
+            syncInitialAttributes();
           } else {
-            hasChildrenChange = true;
+            // async & unresolved
+            Component().then(resolved => {
+              if (resolved.__esModule || resolved[Symbol.toStringTag] === 'Module') {
+                resolved = resolved.default;
+              }
+              initialize(resolved);
+              syncInitialAttributes();
+            });
           }
-        }
-        if (hasChildrenChange) {
+          // initialize children
           wrapper.slotChildren = Object.freeze(toVNodes(
             wrapper.$createElement,
-            self.childNodes
+            this.childNodes
           ));
-        }
-      });
-      observer.observe(self, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-        attributes: true
-      });
-    }
-
-    get vueComponent () {
-      return this._wrapper.$refs.inner
-    }
-
-    connectedCallback () {
-      const wrapper = this._wrapper;
-      if (!wrapper._isMounted) {
-        // initialize attributes
-        const syncInitialAttributes = () => {
-          wrapper.props = getInitialProps(camelizedPropsList);
-          hyphenatedPropsList.forEach(key => {
-            syncAttribute(this, key);
-          });
-        };
-
-        if (isInitialized) {
-          syncInitialAttributes();
+          wrapper.$mount();
+          this.shadowRoot.appendChild(wrapper.$el);
         } else {
-          // async & unresolved
-          Component().then(resolved => {
-            if (resolved.__esModule || resolved[Symbol.toStringTag] === 'Module') {
-              resolved = resolved.default;
-            }
-            initialize(resolved);
-            syncInitialAttributes();
-          });
+          callHooks(this.vueComponent, 'activated');
         }
-        // initialize children
-        wrapper.slotChildren = Object.freeze(toVNodes(
-          wrapper.$createElement,
-          this.childNodes
-        ));
-        wrapper.$mount();
-        this.shadowRoot.appendChild(wrapper.$el);
-      } else {
-        callHooks(this.vueComponent, 'activated');
+      }
+
+      disconnectedCallback () {
+        callHooks(this.vueComponent, 'deactivated');
       }
     }
 
-    disconnectedCallback () {
-      callHooks(this.vueComponent, 'deactivated');
+    if (!isAsync) {
+      initialize(Component);
     }
+
+    return CustomElement
   }
 
-  if (!isAsync) {
-    initialize(Component);
-  }
+  return wrap;
 
-  return CustomElement
-}
-
-return wrap;
-
-}());
+})();

--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -1,283 +1,281 @@
 var wrapVueWebComponent = (function () {
-  'use strict';
+'use strict';
 
-  const camelizeRE = /-(\w)/g;
-  const camelize = str => {
-    return str.replace(camelizeRE, (_, c) => c ? c.toUpperCase() : '')
-  };
+const camelizeRE = /-(\w)/g;
+const camelize = str => {
+  return str.replace(camelizeRE, (_, c) => c ? c.toUpperCase() : '')
+};
 
-  const hyphenateRE = /\B([A-Z])/g;
-  const hyphenate = str => {
-    return str.replace(hyphenateRE, '-$1').toLowerCase()
-  };
+const hyphenateRE = /\B([A-Z])/g;
+const hyphenate = str => {
+  return str.replace(hyphenateRE, '-$1').toLowerCase()
+};
 
-  function getInitialProps (propsList) {
-    const res = {};
-    propsList.forEach(key => {
-      res[key] = undefined;
+function getInitialProps (propsList) {
+  const res = {};
+  propsList.forEach(key => {
+    res[key] = undefined;
+  });
+  return res
+}
+
+function injectHook (options, key, hook) {
+  options[key] = [].concat(options[key] || []);
+  options[key].unshift(hook);
+}
+
+function callHooks (vm, hook) {
+  if (vm) {
+    const hooks = vm.$options[hook] || [];
+    hooks.forEach(hook => {
+      hook.call(vm);
     });
-    return res
   }
+}
 
-  function injectHook (options, key, hook) {
-    options[key] = [].concat(options[key] || []);
-    options[key].unshift(hook);
-  }
+function createCustomEvent (name, args) {
+  return new CustomEvent(name, {
+    bubbles: false,
+    cancelable: false,
+    detail: args
+  })
+}
 
-  function callHooks (vm, hook) {
-    if (vm) {
-      const hooks = vm.$options[hook] || [];
-      hooks.forEach(hook => {
-        hook.call(vm);
-      });
+const isBoolean = val => /function Boolean/.test(String(val));
+const isNumber = val => /function Number/.test(String(val));
+
+function convertAttributeValue (value, name, { type } = {}) {
+  if (isBoolean(type)) {
+    if (value === 'true' || value === 'false') {
+      return value === 'true'
     }
+    if (value === '' || value === name || value != null) {
+      return true
+    }
+    return value
+  } else if (isNumber(type)) {
+    const parsed = parseFloat(value, 10);
+    return isNaN(parsed) ? value : parsed
+  } else {
+    return value
   }
+}
 
-  function createCustomEvent (name, args) {
-    return new CustomEvent(name, {
-      bubbles: false,
-      cancelable: false,
-      detail: args
-    })
+function toVNodes (h, children) {
+  const res = [];
+  for (let i = 0, l = children.length; i < l; i++) {
+    res.push(toVNode(h, children[i]));
   }
+  return res
+}
 
-  const isBoolean = val => /function Boolean/.test(String(val));
-  const isNumber = val => /function Number/.test(String(val));
-
-  function convertAttributeValue (value, name, { type } = {}) {
-    if (isBoolean(type)) {
-      if (value === 'true' || value === 'false') {
-        return value === 'true'
+function toVNode (h, node) {
+  if (node.nodeType === 3) {
+    return node.data.trim() ? node.data : null
+  } else if (node.nodeType === 1) {
+    const data = {
+      attrs: getAttributes(node),
+      domProps: {
+        innerHTML: node.innerHTML
       }
-      if (value === '' || value === name || value != null) {
-        return true
-      }
-      return value
-    } else if (isNumber(type)) {
-      const parsed = parseFloat(value, 10);
-      return isNaN(parsed) ? value : parsed
-    } else {
-      return value
+    };
+    if (data.attrs.slot) {
+      data.slot = data.attrs.slot;
+      delete data.attrs.slot;
     }
+    return h(node.tagName, data)
+  } else {
+    return null
   }
+}
 
-  function toVNodes (h, children) {
-    const res = [];
-    for (let i = 0, l = children.length; i < l; i++) {
-      res.push(toVNode(h, children[i]));
-    }
-    return res
+function getAttributes (node) {
+  const res = {};
+  for (let i = 0, l = node.attributes.length; i < l; i++) {
+    const attr = node.attributes[i];
+    res[attr.nodeName] = attr.nodeValue;
   }
+  return res
+}
 
-  function toVNode (h, node) {
-    if (node.nodeType === 3) {
-      return node.data.trim() ? node.data : null
-    } else if (node.nodeType === 1) {
-      const data = {
-        attrs: getAttributes(node),
-        domProps: {
-          innerHTML: node.innerHTML
-        }
+function wrap (Vue, Component) {
+  const isAsync = typeof Component === 'function' && !Component.cid;
+  let isInitialized = false;
+  let hyphenatedPropsList;
+  let camelizedPropsList;
+  let camelizedPropsMap;
+
+  function initialize (Component) {
+    if (isInitialized) return
+
+    const options = typeof Component === 'function'
+      ? Component.options
+      : Component;
+
+    // extract props info
+    const propsList = Array.isArray(options.props)
+      ? options.props
+      : Object.keys(options.props || {});
+    hyphenatedPropsList = propsList.map(hyphenate);
+    camelizedPropsList = propsList.map(camelize);
+    const originalPropsAsObject = Array.isArray(options.props) ? {} : options.props || {};
+    camelizedPropsMap = camelizedPropsList.reduce((map, key, i) => {
+      map[key] = originalPropsAsObject[propsList[i]];
+      return map
+    }, {});
+
+    // proxy $emit to native DOM events
+    injectHook(options, 'beforeCreate', function () {
+      const emit = this.$emit;
+      this.$emit = (name, ...args) => {
+        this.$root.$options.customElement.dispatchEvent(createCustomEvent(name, args));
+        return emit.call(this, name, ...args)
       };
-      if (data.attrs.slot) {
-        data.slot = data.attrs.slot;
-        delete data.attrs.slot;
-      }
-      return h(node.tagName, data)
-    } else {
-      return null
-    }
-  }
+    });
 
-  function getAttributes (node) {
-    const res = {};
-    for (let i = 0, l = node.attributes.length; i < l; i++) {
-      const attr = node.attributes[i];
-      res[attr.nodeName] = attr.nodeValue;
-    }
-    return res
-  }
-
-  function wrap (Vue, Component) {
-    const isAsync = typeof Component === 'function' && !Component.cid;
-    let isInitialized = false;
-    let hyphenatedPropsList;
-    let camelizedPropsList;
-    let camelizedPropsMap;
-
-    function initialize (Component) {
-      if (isInitialized) return
-
-      const options = typeof Component === 'function'
-        ? Component.options
-        : Component;
-
-      // extract props info
-      const propsList = Array.isArray(options.props)
-        ? options.props
-        : Object.keys(options.props || {});
-      hyphenatedPropsList = propsList.map(hyphenate);
-      camelizedPropsList = propsList.map(camelize);
-      const originalPropsAsObject = Array.isArray(options.props) ? {} : options.props || {};
-      camelizedPropsMap = camelizedPropsList.reduce((map, key, i) => {
-        map[key] = originalPropsAsObject[propsList[i]];
-        return map
-      }, {});
-
-      // proxy $emit to native DOM events
-      injectHook(options, 'beforeCreate', function () {
-        const emit = this.$emit;
-        this.$emit = (name, ...args) => {
-          this.$root.$options.customElement.dispatchEvent(createCustomEvent(name, args));
-          return emit.call(this, name, ...args)
-        };
-      });
-
-      injectHook(options, 'created', function () {
-        // sync default props values to wrapper on created
-        camelizedPropsList.forEach(key => {
-          this.$root.props[key] = this[key];
-        });
-      });
-
-      // proxy methods as Element methods
-      Object.keys(options.methods || {}).forEach(key => {
-        Object.defineProperty(CustomElement.prototype, key, {
-          value (...args) {
-            // _wrapper.$refs.inner
-            return options.methods[key].call(this.vueComponent, ...args)
-            //return this.vueComponent[key](...args)
-          }
-        });
-      });
-
-      // proxy props as Element properties
+    injectHook(options, 'created', function () {
+      // sync default props values to wrapper on created
       camelizedPropsList.forEach(key => {
-        Object.defineProperty(CustomElement.prototype, key, {
-          get () {
-            return this._wrapper.props[key]
-          },
-          set (newVal) {
-            this._wrapper.props[key] = newVal;
-          },
-          enumerable: false,
-          configurable: true
-        });
+        this.$root.props[key] = this[key];
+      });
+    });
+
+    // proxy methods as Element methods
+    Object.keys(options.methods || {}).forEach(key => {
+      Object.defineProperty(CustomElement.prototype, key, {
+        value (...args) {
+          return options.methods[key].call(this.vueComponent, ...args)
+        }
+      });
+    });
+
+    // proxy props as Element properties
+    camelizedPropsList.forEach(key => {
+      Object.defineProperty(CustomElement.prototype, key, {
+        get () {
+          return this._wrapper.props[key]
+        },
+        set (newVal) {
+          this._wrapper.props[key] = newVal;
+        },
+        enumerable: false,
+        configurable: true
+      });
+    });
+
+    isInitialized = true;
+  }
+
+  function syncAttribute (el, key) {
+    const camelized = camelize(key);
+    const value = el.hasAttribute(key) ? el.getAttribute(key) : undefined;
+    el._wrapper.props[camelized] = convertAttributeValue(
+      value,
+      key,
+      camelizedPropsMap[camelized]
+    );
+  }
+
+  class CustomElement extends HTMLElement {
+    constructor () {
+      const self = super();
+      self.attachShadow({ mode: 'open' });
+
+      const wrapper = self._wrapper = new Vue({
+        name: 'shadow-root',
+        customElement: self,
+        shadowRoot: self.shadowRoot,
+        data () {
+          return {
+            props: {},
+            slotChildren: []
+          }
+        },
+        render (h) {
+          return h(Component, {
+            ref: 'inner',
+            props: this.props
+          }, this.slotChildren)
+        }
       });
 
-      isInitialized = true;
-    }
-
-    function syncAttribute (el, key) {
-      const camelized = camelize(key);
-      const value = el.hasAttribute(key) ? el.getAttribute(key) : undefined;
-      el._wrapper.props[camelized] = convertAttributeValue(
-        value,
-        key,
-        camelizedPropsMap[camelized]
-      );
-    }
-
-    class CustomElement extends HTMLElement {
-      constructor () {
-        const self = super();
-        self.attachShadow({ mode: 'open' });
-
-        const wrapper = self._wrapper = new Vue({
-          name: 'shadow-root',
-          customElement: self,
-          shadowRoot: self.shadowRoot,
-          data () {
-            return {
-              props: {},
-              slotChildren: []
-            }
-          },
-          render (h) {
-            return h(Component, {
-              ref: 'inner',
-              props: this.props
-            }, this.slotChildren)
-          }
-        });
-
-        // Use MutationObserver to react to future attribute & slot content change
-        const observer = new MutationObserver(mutations => {
-          let hasChildrenChange = false;
-          for (let i = 0; i < mutations.length; i++) {
-            const m = mutations[i];
-            if (isInitialized && m.type === 'attributes' && m.target === self) {
-              syncAttribute(self, m.attributeName);
-            } else {
-              hasChildrenChange = true;
-            }
-          }
-          if (hasChildrenChange) {
-            wrapper.slotChildren = Object.freeze(toVNodes(
-              wrapper.$createElement,
-              self.childNodes
-            ));
-          }
-        });
-        observer.observe(self, {
-          childList: true,
-          subtree: true,
-          characterData: true,
-          attributes: true
-        });
-      }
-
-      get vueComponent () {
-        return this._wrapper.$refs.inner
-      }
-
-      connectedCallback () {
-        const wrapper = this._wrapper;
-        if (!wrapper._isMounted) {
-          // initialize attributes
-          const syncInitialAttributes = () => {
-            wrapper.props = getInitialProps(camelizedPropsList);
-            hyphenatedPropsList.forEach(key => {
-              syncAttribute(this, key);
-            });
-          };
-
-          if (isInitialized) {
-            syncInitialAttributes();
+      // Use MutationObserver to react to future attribute & slot content change
+      const observer = new MutationObserver(mutations => {
+        let hasChildrenChange = false;
+        for (let i = 0; i < mutations.length; i++) {
+          const m = mutations[i];
+          if (isInitialized && m.type === 'attributes' && m.target === self) {
+            syncAttribute(self, m.attributeName);
           } else {
-            // async & unresolved
-            Component().then(resolved => {
-              if (resolved.__esModule || resolved[Symbol.toStringTag] === 'Module') {
-                resolved = resolved.default;
-              }
-              initialize(resolved);
-              syncInitialAttributes();
-            });
+            hasChildrenChange = true;
           }
-          // initialize children
+        }
+        if (hasChildrenChange) {
           wrapper.slotChildren = Object.freeze(toVNodes(
             wrapper.$createElement,
-            this.childNodes
+            self.childNodes
           ));
-          wrapper.$mount();
-          this.shadowRoot.appendChild(wrapper.$el);
-        } else {
-          callHooks(this.vueComponent, 'activated');
         }
-      }
+      });
+      observer.observe(self, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true
+      });
+    }
 
-      disconnectedCallback () {
-        callHooks(this.vueComponent, 'deactivated');
+    get vueComponent () {
+      return this._wrapper.$refs.inner
+    }
+
+    connectedCallback () {
+      const wrapper = this._wrapper;
+      if (!wrapper._isMounted) {
+        // initialize attributes
+        const syncInitialAttributes = () => {
+          wrapper.props = getInitialProps(camelizedPropsList);
+          hyphenatedPropsList.forEach(key => {
+            syncAttribute(this, key);
+          });
+        };
+
+        if (isInitialized) {
+          syncInitialAttributes();
+        } else {
+          // async & unresolved
+          Component().then(resolved => {
+            if (resolved.__esModule || resolved[Symbol.toStringTag] === 'Module') {
+              resolved = resolved.default;
+            }
+            initialize(resolved);
+            syncInitialAttributes();
+          });
+        }
+        // initialize children
+        wrapper.slotChildren = Object.freeze(toVNodes(
+          wrapper.$createElement,
+          this.childNodes
+        ));
+        wrapper.$mount();
+        this.shadowRoot.appendChild(wrapper.$el);
+      } else {
+        callHooks(this.vueComponent, 'activated');
       }
     }
 
-    if (!isAsync) {
-      initialize(Component);
+    disconnectedCallback () {
+      callHooks(this.vueComponent, 'deactivated');
     }
-
-    return CustomElement
   }
 
-  return wrap;
+  if (!isAsync) {
+    initialize(Component);
+  }
+
+  return CustomElement
+}
+
+return wrap;
 
 })();

--- a/dist/vue-wc-wrapper.global.js
+++ b/dist/vue-wc-wrapper.global.js
@@ -278,4 +278,4 @@ function wrap (Vue, Component) {
 
 return wrap;
 
-})();
+}());

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -137,6 +137,17 @@ function wrap (Vue, Component) {
       });
     });
 
+    // proxy methods as Element methods
+    Object.keys(options.methods || {}).forEach(key => {
+      Object.defineProperty(CustomElement.prototype, key, {
+        value (...args) {
+          // _wrapper.$refs.inner
+          return options.methods[key].call(this.vueComponent, ...args)
+          //return this.vueComponent[key](...args)
+        }
+      });
+    });
+
     // proxy props as Element properties
     camelizedPropsList.forEach(key => {
       Object.defineProperty(CustomElement.prototype, key, {
@@ -264,4 +275,4 @@ function wrap (Vue, Component) {
   return CustomElement
 }
 
-export default wrap;
+export { wrap as default };

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -141,9 +141,7 @@ function wrap (Vue, Component) {
     Object.keys(options.methods || {}).forEach(key => {
       Object.defineProperty(CustomElement.prototype, key, {
         value (...args) {
-          // _wrapper.$refs.inner
           return options.methods[key].call(this.vueComponent, ...args)
-          //return this.vueComponent[key](...args)
         }
       });
     });

--- a/dist/vue-wc-wrapper.js
+++ b/dist/vue-wc-wrapper.js
@@ -273,4 +273,4 @@ function wrap (Vue, Component) {
   return CustomElement
 }
 
-export { wrap as default };
+export default wrap;

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,15 @@ export default function wrap (Vue, Component) {
       })
     })
 
+    // proxy methods as Element methods
+    Object.keys(options.methods || {}).forEach(key => {
+      Object.defineProperty(CustomElement.prototype, key, {
+        value (...args) {
+          return options.methods[key].call(this.vueComponent, ...args)
+        }
+      })
+    })
+
     // proxy props as Element properties
     camelizedPropsList.forEach(key => {
       Object.defineProperty(CustomElement.prototype, key, {


### PR DESCRIPTION
This adds a JavaScript-API similar to what HTMLMediaElements like <audio> offer – such as you can call `play()`, `seek(10)`, and other methods directly on the HTMLElement – by proxying the Vue2-component’s methods onto the CustomElement.

This closes #73 